### PR TITLE
Make unread messages count available from notification extension helper.

### DIFF
--- a/Sources/AppExtensions/NotificationExtensionHelper.swift
+++ b/Sources/AppExtensions/NotificationExtensionHelper.swift
@@ -18,6 +18,10 @@ public class NotificationExtensionHelper {
         }
         self.userDefaults = userDefaults
     }
+    
+    public var unreadNotifications: Int {
+        return userDefaults.integer(forKey: "io.rover.unreadNotifications")
+    }
 
     @discardableResult
     public func didReceive(_ request: UNNotificationRequest, withContent content: UNMutableNotificationContent) -> Bool {

--- a/Sources/Notifications/NotificationsAssembler.swift
+++ b/Sources/Notifications/NotificationsAssembler.swift
@@ -88,7 +88,8 @@ public struct NotificationsAssembler: Assembler {
         container.register(NotificationStore.self) { [maxNotifications] resolver in
             NotificationStoreService(
                 maxSize: maxNotifications,
-                eventQueue: resolver.resolve(EventQueue.self)
+                eventQueue: resolver.resolve(EventQueue.self),
+                userDefaults: UserDefaults(suiteName: self.appGroup)!
             )
         }
         


### PR DESCRIPTION
Resolves https://github.com/RoverPlatform/rover-ios/issues/458 .