### PR TITLE
v3.0.0-beta.3: Regression on Swift 4.2 compiler.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,32 +1,32 @@
 PODS:
-  - Rover (3.0.0-beta.5)
-  - RoverAppExtensions (3.0.0-beta.2)
-  - RoverCampaigns/AdSupport (3.0.0-beta.2):
+  - Rover (3.0.0-beta.6)
+  - RoverAppExtensions (3.0.0-beta.3)
+  - RoverCampaigns/AdSupport (3.0.0-beta.3):
     - RoverCampaigns/Data
-  - RoverCampaigns/Bluetooth (3.0.0-beta.2):
+  - RoverCampaigns/Bluetooth (3.0.0-beta.3):
     - RoverCampaigns/Data
-  - RoverCampaigns/Core (3.0.0-beta.2):
+  - RoverCampaigns/Core (3.0.0-beta.3):
     - RoverCampaigns/Debug
     - RoverCampaigns/Experiences
     - RoverCampaigns/Location
     - RoverCampaigns/Notifications
-  - RoverCampaigns/Data (3.0.0-beta.2):
+  - RoverCampaigns/Data (3.0.0-beta.3):
     - RoverCampaigns/Foundation
-  - RoverCampaigns/Debug (3.0.0-beta.2):
+  - RoverCampaigns/Debug (3.0.0-beta.3):
     - RoverCampaigns/UI
-  - RoverCampaigns/Experiences (3.0.0-beta.2):
-    - Rover (~> 3.0.0-beta.5)
+  - RoverCampaigns/Experiences (3.0.0-beta.3):
+    - Rover (~> 3.0.0-beta.6)
     - RoverCampaigns/UI
-  - RoverCampaigns/Foundation (3.0.0-beta.2)
-  - RoverCampaigns/Location (3.0.0-beta.2):
+  - RoverCampaigns/Foundation (3.0.0-beta.3)
+  - RoverCampaigns/Location (3.0.0-beta.3):
     - RoverCampaigns/Data
-  - RoverCampaigns/Notifications (3.0.0-beta.2):
+  - RoverCampaigns/Notifications (3.0.0-beta.3):
     - RoverCampaigns/UI
-  - RoverCampaigns/Telephony (3.0.0-beta.2):
+  - RoverCampaigns/Telephony (3.0.0-beta.3):
     - RoverCampaigns/Data
-  - RoverCampaigns/Ticketmaster (3.0.0-beta.2):
+  - RoverCampaigns/Ticketmaster (3.0.0-beta.3):
     - RoverCampaigns/Data
-  - RoverCampaigns/UI (3.0.0-beta.2):
+  - RoverCampaigns/UI (3.0.0-beta.3):
     - RoverCampaigns/Data
 
 DEPENDENCIES:
@@ -48,9 +48,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Rover: d44c06a5e57f02ee31b74fd8e7a6e43ad1fb5dae
-  RoverAppExtensions: 1c99dad7965487daebcf6fb362a408150eba4f77
-  RoverCampaigns: 03279c036bbfec3b9b978975fe515914b421d2e5
+  Rover: e68b4b3e93790b8056ae1a0c10541159222be129
+  RoverAppExtensions: edc4e95ae287256ad407e226c9438679ed0261f5
+  RoverCampaigns: 539b2573fc253919082bc572fb1f0244dae473d4
 
 PODFILE CHECKSUM: 4e581bed0b2417138aab8d6c224c12cf7e9d4f5a
 

--- a/RoverAppExtensions.podspec
+++ b/RoverAppExtensions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "RoverAppExtensions"
-  s.version           = "3.0.0-beta.2"
+  s.version           = "3.0.0-beta.3"
   s.summary           = "Rover Campaigns iOS App Extensions"
   s.homepage          = "https://www.rover.io"
   s.license           = "Apache License, Version 2.0"

--- a/RoverCampaigns.podspec
+++ b/RoverCampaigns.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "RoverCampaigns"
-  s.version           = "3.0.0-beta.2"
+  s.version           = "3.0.0-beta.3"
   s.summary           = "iOS framework for the Rover Campaigns app"
   s.homepage          = "https://www.rover.io"
   s.license           = "Apache License, Version 2.0"

--- a/Sources/AdSupport/Info.plist
+++ b/Sources/AdSupport/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/AppExtensions/Info.plist
+++ b/Sources/AppExtensions/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Bluetooth/Info.plist
+++ b/Sources/Bluetooth/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Data/Info.plist
+++ b/Sources/Data/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Data/Vendor/Data+Compression.swift
+++ b/Sources/Data/Vendor/Data+Compression.swift
@@ -436,12 +436,14 @@ public struct Adler32: CustomStringConvertible
 
 extension Data
 {
-    func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType
-    {
-        return try self.withUnsafeBytes({ (rawBufferPointer: UnsafeRawBufferPointer) -> ResultType in
-            return try body(rawBufferPointer.bindMemory(to: ContentType.self).baseAddress!)
-        })
-    }
+// Commented out because not compatible with the Swift 4.x compiler, and not needed for our use case.
+    
+//    func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType
+//    {
+//        return try self.withUnsafeBytes({ (rawBufferPointer: UnsafeRawBufferPointer) -> ResultType in
+//            return try body(rawBufferPointer.bindMemory(to: ContentType.self).baseAddress!)
+//        })
+//    }
 }
 
 fileprivate extension Data.CompressionAlgorithm

--- a/Sources/Debug/Info.plist
+++ b/Sources/Debug/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Experiences/Info.plist
+++ b/Sources/Experiences/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/Foundation/Info.plist
+++ b/Sources/Foundation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Location/Info.plist
+++ b/Sources/Location/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Notifications/Info.plist
+++ b/Sources/Notifications/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Telephony/Info.plist
+++ b/Sources/Telephony/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/Ticketmaster/Info.plist
+++ b/Sources/Ticketmaster/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/UI/Info.plist
+++ b/Sources/UI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0-beta.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
While we built successfully with the Swift 4.2 language mode on the 5.x compiler, that can often be no guarantee of compatibility.

This fix restores us to building and running properly on the Swift 4.2 compiler (Xcode 10.1).