### PR TITLE
Ensure that GraphQL Query URIs are generated with keys in consistent order.

### DIFF
--- a/Sources/Data/SyncCoordinator/SyncClient.swift
+++ b/Sources/Data/SyncCoordinator/SyncClient.swift
@@ -37,10 +37,12 @@ extension SyncClient {
                 """
         }()
         
-        let fragments: [String]? = {
+        let fragmentsUnsorted: [String]? = {
             let fragments = syncRequests.map { Set($0.query.fragments) }.reduce(Set<String>()) { $0.union($1) }
             return Array(fragments)
         }()
+        
+        let fragments = fragmentsUnsorted?.sorted()
         
         let variablesDict: [String: Any] = {
             syncRequests.reduce([String: Any]()) { result, request in

--- a/Sources/Foundation/Extensions/Foundation.JSONEncoder.swift
+++ b/Sources/Foundation/Extensions/Foundation.JSONEncoder.swift
@@ -12,6 +12,10 @@ extension JSONEncoder {
     public static let `default`: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .formatted(DateFormatter.rfc3339)
+        if #available(iOS 11.0, *) {
+            // Stable ordering of the keys is very helpful with GraphQL caching on the cloud API side.
+            encoder.outputFormatting = [.sortedKeys]
+        }
         return encoder
     }()
 }


### PR DESCRIPTION
This will be very helpful with the team's efforts to enable effective caching on GraphQL.

Resolves #66.
