### PR TITLE
Support for `screenID` experience deep link parameter.

### DIFF
--- a/RoverCampaigns.podspec
+++ b/RoverCampaigns.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
   s.subspec "Experiences" do |ss|
     ss.source_files = "Sources/Experiences/**/*.swift"
     ss.dependency "RoverCampaigns/UI"
-    ss.dependency "Rover", "~> 3.4"
+    ss.dependency "Rover", "~> 3.5"
     ss.frameworks = "WebKit"
   end
 

--- a/Sources/Experiences/ExperiencesAssembler.swift
+++ b/Sources/Experiences/ExperiencesAssembler.swift
@@ -16,8 +16,8 @@ public struct ExperiencesAssembler: Assembler {
         
         // MARK: Action (presentExperience)
         
-        container.register(Action.self, name: "presentExperience", scope: .transient) { (resolver, id: String, campaignID: String?) in
-            let viewControllerToPresent = resolver.resolve(UIViewController.self, name: "experience", arguments: id, campaignID)!
+        container.register(Action.self, name: "presentExperience", scope: .transient) { (resolver, id: String, campaignID: String?, screenID: String?) in
+            let viewControllerToPresent = resolver.resolve(UIViewController.self, name: "experience", arguments: id, campaignID, screenID)!
             return resolver.resolve(Action.self, name: "presentView", arguments: viewControllerToPresent)!
         }
         
@@ -29,8 +29,8 @@ public struct ExperiencesAssembler: Assembler {
         // MARK: RouteHandler (experience)
         
         container.register(RouteHandler.self, name: "experience") { resolver in            
-            let idActionProvider: (String, String?) -> Action? = { [weak resolver] id, campaignID in
-                resolver?.resolve(Action.self, name: "presentExperience", arguments: id, campaignID)
+            let idActionProvider: (String, String?, String?) -> Action? = { [weak resolver] id, campaignID, screenID in
+                resolver?.resolve(Action.self, name: "presentExperience", arguments: id, campaignID, screenID)
             }
                 
             let universalLinkActionProvider: (URL, String?) -> Action? = { [weak resolver] universalLink, campaignID in
@@ -51,9 +51,9 @@ public struct ExperiencesAssembler: Assembler {
         
         // MARK: UIViewController (experience)
         
-        container.register(UIViewController.self, name: "experience", scope: .transient) { (resolver, id: String, campaignID: String?) in
+        container.register(UIViewController.self, name: "experience", scope: .transient) { (resolver, id: String, campaignID: String?, screenID: String?) in
             let viewController = RoverViewController()
-            viewController.loadExperience(id: id, campaignID: campaignID)
+            viewController.loadExperience(id: id, campaignID: campaignID, initialScreenID: screenID)
             return viewController
         }
         

--- a/Sources/Experiences/RouteHandlers/ExperienceRouteHandler.swift
+++ b/Sources/Experiences/RouteHandlers/ExperienceRouteHandler.swift
@@ -9,10 +9,11 @@
 import Foundation
 
 class ExperienceRouteHandler: RouteHandler {
-    let idActionProvider: (String, String?) -> Action?
+    /// A closure for providing an Action for opening an Experience. (ExperienceID, CampaignID?, ScreenID?).
+    let idActionProvider: (String, String?, String?) -> Action?
     let universalLinkActionProvider: (URL, String?) -> Action?
     
-    init(idActionProvider: @escaping (String, String?) -> Action?, universalLinkActionProvider: @escaping (URL, String?) -> Action?) {
+    init(idActionProvider: @escaping (String, String?, String?) -> Action?, universalLinkActionProvider: @escaping (URL, String?) -> Action?) {
         self.idActionProvider = idActionProvider
         self.universalLinkActionProvider = universalLinkActionProvider
     }
@@ -35,7 +36,9 @@ class ExperienceRouteHandler: RouteHandler {
         }
 
         let campaignID = queryItems.first(where: { $0.name == "campaignID" })?.value
-        return idActionProvider(experienceID, campaignID)
+        let screenID = queryItems.first(where: { $0.name == "screenID" })?.value
+        
+        return idActionProvider(experienceID, campaignID, screenID)
     }
     
     func universalLinkAction(url: URL) -> Action? {


### PR DESCRIPTION
Bumps dependency on Rover to 3.5, attendant for Screen ID support.

Resolves #80.