### PR TITLE
Support for Screen Viewed Event for Advanced Data Package

### DIFF
--- a/Sources/Data/EventQueue/EventInfo.swift
+++ b/Sources/Data/EventQueue/EventInfo.swift
@@ -32,7 +32,7 @@ public extension EventInfo {
         screenLabel: String? = nil,
         contentID: String? = nil
     ) {
-        var attributes = [
+        let attributes: Attributes = [
             "screenName": screenName
         ]
         
@@ -44,10 +44,7 @@ public extension EventInfo {
             attributes["contentID"] = contentID
         }
         
-        self.name = "Screen Viewed"
         // using a nil namespace to represent events for screens owned by the app vendor.
-        self.namespace = nil
-        self.attributes = Attributes(rawValue: attributes)
-        self.timestamp = Date()
+        self.init(name: "Screen Viewed", attributes: attributes)
     }
 }

--- a/Sources/Data/EventQueue/EventInfo.swift
+++ b/Sources/Data/EventQueue/EventInfo.swift
@@ -24,3 +24,30 @@ public struct EventInfo {
         self.timestamp = timestamp
     }
 }
+
+public extension EventInfo {
+    /// Create an EventInfo that tracks a Screen Viewed event for Analytics use.  Use it for tracking screens & content in your app belonging to components other than Rover.
+    init(
+        forViewingScreenWithName screenName: String,
+        screenLabel: String? = nil,
+        contentID: String? = nil
+    ) {
+        var attributes = [
+            "screenName": screenName
+        ]
+        
+        if let screenLabel = screenLabel {
+            attributes["screenLabel"] = screenLabel
+        }
+        
+        if let contentID = contentID {
+            attributes["contentID"] = contentID
+        }
+        
+        self.name = "Screen Viewed"
+        // using a nil namespace to represent events for screens owned by the app vendor.
+        self.namespace = nil
+        self.attributes = Attributes(rawValue: attributes)
+        self.timestamp = Date()
+    }
+}


### PR DESCRIPTION
@seanrucker thoughts if the extension method should move to its own file?

Usage:

```swift
RoverCampaigns.shared!.resolve(EventQueue.self)!.addEvent(
    EventInfo(
        forViewingScreenWithName: "Article",
        screenLabel: "This Season's Lineup",
        contentID: "1701"
    )
)
```

Resolves #90.