### PR TITLE
Include User Info in log messages.

### DIFF
--- a/RoverCampaigns.xcodeproj/project.pbxproj
+++ b/RoverCampaigns.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0DB764912256C5DD00038605 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB764902256C5DD00038605 /* Data+Compression.swift */; };
+		499A689C23E47D5400C24C23 /* Foundation.Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499A689B23E47D5300C24C23 /* Foundation.Error.swift */; };
 		49EE59702326E3FC0051EC71 /* DarkModeContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EE596F2326E3FB0051EC71 /* DarkModeContextProvider.swift */; };
 		49F7CE67223C2B1F00674784 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F7CE64223C2B1F00674784 /* Session.swift */; };
 		49F7CE68223C2B1F00674784 /* SessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F7CE65223C2B1F00674784 /* SessionController.swift */; };
@@ -297,6 +298,7 @@
 /* Begin PBXFileReference section */
 		0DB764902256C5DD00038605 /* Data+Compression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
 		492A84A32238351C00B59A5C /* RoverObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoverObserver.swift; sourceTree = "<group>"; };
+		499A689B23E47D5300C24C23 /* Foundation.Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Foundation.Error.swift; sourceTree = "<group>"; };
 		49EE596F2326E3FB0051EC71 /* DarkModeContextProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DarkModeContextProvider.swift; sourceTree = "<group>"; };
 		49F7CE64223C2B1F00674784 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		49F7CE65223C2B1F00674784 /* SessionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionController.swift; sourceTree = "<group>"; };
@@ -1469,6 +1471,7 @@
 		DBFDF52220AE2B0B0031EF47 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				499A689B23E47D5300C24C23 /* Foundation.Error.swift */,
 				DBFDF52320AE2B1C0031EF47 /* Foundation.DateFormatter.swift */,
 				DBCBE087216140F1001C7A96 /* Foundation.JSONDecoder.swift */,
 				DBCBE085216140E6001C7A96 /* Foundation.JSONEncoder.swift */,
@@ -1659,7 +1662,6 @@
 				DB6ADD5620B33EC0002F226C /* Frameworks */,
 				DB6ADD5720B33EC0002F226C /* Headers */,
 				DB6ADD5820B33EC0002F226C /* Resources */,
-				4953CDA32231747D000986C8 /* Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -2352,27 +2354,6 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		4953CDA32231747D000986C8 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
 		DB0C8F1C20583A5600E0D860 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -2657,6 +2638,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				499A689C23E47D5400C24C23 /* Foundation.Error.swift in Sources */,
 				DBADA7FC20A4F32500225C80 /* ActionObserver.swift in Sources */,
 				DBF49E02203DE1DE00B54652 /* Assembler.swift in Sources */,
 				DBADA7FB20A4F32500225C80 /* Action.swift in Sources */,

--- a/Sources/AppExtensions/NotificationExtensionHelper.swift
+++ b/Sources/AppExtensions/NotificationExtensionHelper.swift
@@ -122,7 +122,7 @@ public class NotificationExtensionHelper {
         let downloadResult = downloadAttachment(attachmentURL)
 
         if let error = downloadResult.error {
-            print(error.localizedDescription)
+            print(error.debugDescription)
             return
         }
 

--- a/Sources/AppExtensions/NotificationExtensionHelper.swift
+++ b/Sources/AppExtensions/NotificationExtensionHelper.swift
@@ -122,7 +122,7 @@ public class NotificationExtensionHelper {
         let downloadResult = downloadAttachment(attachmentURL)
 
         if let error = downloadResult.error {
-            print(error.debugDescription)
+            print(error.logDescription)
             return
         }
 

--- a/Sources/Data/EventQueue/EventQueue.swift
+++ b/Sources/Data/EventQueue/EventQueue.swift
@@ -115,7 +115,7 @@ public class EventQueue {
                 self.eventQueue = try PropertyListDecoder().decode([Event].self, from: data)
                 os_log("%d event(s) restored from cache", log: .events, type: .debug, self.eventQueue.count)
             } catch {
-                os_log("Failed to restore events from cache: %@", log: .events, type: .error, error.debugDescription)
+                os_log("Failed to restore events from cache: %@", log: .events, type: .error, error.logDescription)
             }
         }
     }
@@ -181,7 +181,7 @@ public class EventQueue {
                 try data.write(to: cache, options: [.atomic])
                 os_log("Cache now contains %d event(s)", log: .events, type: .debug, self.eventQueue.count)
             } catch {
-                os_log("Failed to persist events to cache: %@", log: .events, type: .error, error.debugDescription)
+                os_log("Failed to persist events to cache: %@", log: .events, type: .error, error.logDescription)
             }
         }
     }
@@ -223,7 +223,7 @@ public class EventQueue {
                 switch result {
                 case let .error(error, isRetryable):
                     if let error = error {
-                        os_log("Failed to upload events: %@", log: .events, type: .error, error.debugDescription)
+                        os_log("Failed to upload events: %@", log: .events, type: .error, error.logDescription)
                     }
                     
                     if isRetryable {
@@ -238,7 +238,7 @@ public class EventQueue {
                         os_log("Successfully uploaded %d event(s)", log: .events, type: .debug, events.count)
                         self.removeEvents(events)
                     } catch {
-                        os_log("Failed to upload events: %@", log: .events, type: .error, error.debugDescription)
+                        os_log("Failed to upload events: %@", log: .events, type: .error, error.logDescription)
                         os_log("Will retry failed events", log: .events, type: .info)
                     }
                 }

--- a/Sources/Data/EventQueue/EventQueue.swift
+++ b/Sources/Data/EventQueue/EventQueue.swift
@@ -115,7 +115,7 @@ public class EventQueue {
                 self.eventQueue = try PropertyListDecoder().decode([Event].self, from: data)
                 os_log("%d event(s) restored from cache", log: .events, type: .debug, self.eventQueue.count)
             } catch {
-                os_log("Failed to restore events from cache: %@", log: .events, type: .error, error.localizedDescription)
+                os_log("Failed to restore events from cache: %@", log: .events, type: .error, error.debugDescription)
             }
         }
     }
@@ -181,7 +181,7 @@ public class EventQueue {
                 try data.write(to: cache, options: [.atomic])
                 os_log("Cache now contains %d event(s)", log: .events, type: .debug, self.eventQueue.count)
             } catch {
-                os_log("Failed to persist events to cache: %@", log: .events, type: .error, error.localizedDescription)
+                os_log("Failed to persist events to cache: %@", log: .events, type: .error, error.debugDescription)
             }
         }
     }
@@ -223,7 +223,7 @@ public class EventQueue {
                 switch result {
                 case let .error(error, isRetryable):
                     if let error = error {
-                        os_log("Failed to upload events: %@", log: .events, type: .error, error.localizedDescription)
+                        os_log("Failed to upload events: %@", log: .events, type: .error, error.debugDescription)
                     }
                     
                     if isRetryable {
@@ -238,7 +238,7 @@ public class EventQueue {
                         os_log("Successfully uploaded %d event(s)", log: .events, type: .debug, events.count)
                         self.removeEvents(events)
                     } catch {
-                        os_log("Failed to upload events: %@", log: .events, type: .error, error.localizedDescription)
+                        os_log("Failed to upload events: %@", log: .events, type: .error, error.debugDescription)
                         os_log("Will retry failed events", log: .events, type: .info)
                     }
                 }

--- a/Sources/Data/HTTP/HTTPClient.swift
+++ b/Sources/Data/HTTP/HTTPClient.swift
@@ -50,7 +50,7 @@ extension HTTPClient {
         do {
             encoded = try JSONEncoder.default.encode(payload)
         } catch {
-            os_log("Failed to encode events: %@", log: .networking, type: .error, error.localizedDescription)
+            os_log("Failed to encode events: %@", log: .networking, type: .error, error.debugDescription)
             return nil
         }
         

--- a/Sources/Data/HTTP/HTTPClient.swift
+++ b/Sources/Data/HTTP/HTTPClient.swift
@@ -50,7 +50,7 @@ extension HTTPClient {
         do {
             encoded = try JSONEncoder.default.encode(payload)
         } catch {
-            os_log("Failed to encode events: %@", log: .networking, type: .error, error.debugDescription)
+            os_log("Failed to encode events: %@", log: .networking, type: .error, error.logDescription)
             return nil
         }
         

--- a/Sources/Data/SyncCoordinator/PagingSyncParticipant.swift
+++ b/Sources/Data/SyncCoordinator/PagingSyncParticipant.swift
@@ -60,7 +60,7 @@ extension PagingSyncParticipant {
         do {
             return try JSONDecoder.default.decode(Response.self, from: data)
         } catch {
-            os_log("Failed to decode response: %@", log: .sync, type: .error, error.localizedDescription)
+            os_log("Failed to decode response: %@", log: .sync, type: .error, error.debugDescription)
             return nil
         }
     }
@@ -94,10 +94,10 @@ extension PagingSyncParticipant {
         if let error = saveError {
             if let multipleErrors = (error as NSError).userInfo[NSDetailedErrorsKey] as? [Error] {
                 multipleErrors.forEach {
-                    os_log("Failed to insert objects: %@", log: .sync, type: .error, $0.localizedDescription)
+                    os_log("Failed to insert objects: %@", log: .sync, type: .error, $0.debugDescription)
                 }
             } else {
-                os_log("Failed to insert objects: %@", log: .sync, type: .error, error.localizedDescription)
+                os_log("Failed to insert objects: %@", log: .sync, type: .error, error.debugDescription)
             }
             
             return false

--- a/Sources/Data/SyncCoordinator/PagingSyncParticipant.swift
+++ b/Sources/Data/SyncCoordinator/PagingSyncParticipant.swift
@@ -60,7 +60,7 @@ extension PagingSyncParticipant {
         do {
             return try JSONDecoder.default.decode(Response.self, from: data)
         } catch {
-            os_log("Failed to decode response: %@", log: .sync, type: .error, error.debugDescription)
+            os_log("Failed to decode response: %@", log: .sync, type: .error, error.logDescription)
             return nil
         }
     }
@@ -94,10 +94,10 @@ extension PagingSyncParticipant {
         if let error = saveError {
             if let multipleErrors = (error as NSError).userInfo[NSDetailedErrorsKey] as? [Error] {
                 multipleErrors.forEach {
-                    os_log("Failed to insert objects: %@", log: .sync, type: .error, $0.debugDescription)
+                    os_log("Failed to insert objects: %@", log: .sync, type: .error, $0.logDescription)
                 }
             } else {
-                os_log("Failed to insert objects: %@", log: .sync, type: .error, error.debugDescription)
+                os_log("Failed to insert objects: %@", log: .sync, type: .error, error.logDescription)
             }
             
             return false

--- a/Sources/Data/SyncCoordinator/SyncCoordinatorService.swift
+++ b/Sources/Data/SyncCoordinator/SyncCoordinatorService.swift
@@ -71,7 +71,7 @@ class SyncCoordinatorService: SyncCoordinator {
             switch result {
             case .error(let error, _):
                 if let error = error {
-                    os_log("Sync task failed: %@", log: .sync, type: .error, error.debugDescription)
+                    os_log("Sync task failed: %@", log: .sync, type: .error, error.logDescription)
                 } else {
                     os_log("Sync task failed", log: .sync, type: .error)
                 }

--- a/Sources/Data/SyncCoordinator/SyncCoordinatorService.swift
+++ b/Sources/Data/SyncCoordinator/SyncCoordinatorService.swift
@@ -71,7 +71,7 @@ class SyncCoordinatorService: SyncCoordinator {
             switch result {
             case .error(let error, _):
                 if let error = error {
-                    os_log("Sync task failed: %@", log: .sync, type: .error, error.localizedDescription)
+                    os_log("Sync task failed: %@", log: .sync, type: .error, error.debugDescription)
                 } else {
                     os_log("Sync task failed", log: .sync, type: .error)
                 }

--- a/Sources/Foundation/Extensions/Foundation.Error.swift
+++ b/Sources/Foundation/Extensions/Foundation.Error.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension Error {
+public extension Error {
     /// Give a more verbose description of an error (particularly, including any details in `userInfo`).
     var debugDescription: String {
         return "Error: \(self.localizedDescription), details: \((self as NSError).userInfo.debugDescription)"

--- a/Sources/Foundation/Extensions/Foundation.Error.swift
+++ b/Sources/Foundation/Extensions/Foundation.Error.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension Error {
     /// Give a more verbose description of an error (particularly, including any details in `userInfo`).
-    var debugDescription: String {
+    var logDescription: String {
         return "Error: \(self.localizedDescription), details: \((self as NSError).userInfo.debugDescription)"
     }
 }

--- a/Sources/Foundation/Extensions/Foundation.Error.swift
+++ b/Sources/Foundation/Extensions/Foundation.Error.swift
@@ -1,0 +1,16 @@
+//
+//  Error.swift
+//  RoverCampaigns
+//
+//  Created by Andrew Clunis on 2020-01-30.
+//  Copyright © 2020 Rover Labs Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Error {
+    /// Give a more verbose description of an error (particularly, including any details in `userInfo`).
+    var debugDescription: String {
+        return "Error: \(self.localizedDescription), details: \((self as NSError).userInfo.debugDescription)"
+    }
+}

--- a/Sources/Foundation/PersistedValue.swift
+++ b/Sources/Foundation/PersistedValue.swift
@@ -36,7 +36,7 @@ public class PersistedValue<T> where T: Codable {
                 do {
                     return try decoder.decode(T.self, from: data)
                 } catch {
-                    os_log("Failed to decode persisted value: %@", log: .general, type: .error, error.saneDescription)
+                    os_log("Failed to decode persisted value: %@", log: .general, type: .error, error.debugDescription)
                     return nil
                 }
             }
@@ -63,7 +63,7 @@ public class PersistedValue<T> where T: Codable {
                     let data = try encoder.encode(newValue)
                     userDefaults.set(data, forKey: storageKey)
                 } catch {
-                    os_log("Failed to encode persisted value: %@", log: .general, type: .error, error.saneDescription)
+                    os_log("Failed to encode persisted value: %@", log: .general, type: .error, error.debugDescription)
                 }
             }
         }
@@ -79,11 +79,5 @@ public class PersistedValue<T> where T: Codable {
         self.encoder = encoder
         self.storageKey = storageKey
         self.userDefaults = userDefaults
-    }
-}
-
-extension Error {
-    var saneDescription: String {
-        return "Error: \(self.localizedDescription), details: \((self as NSError).userInfo.debugDescription)"
     }
 }

--- a/Sources/Foundation/PersistedValue.swift
+++ b/Sources/Foundation/PersistedValue.swift
@@ -36,7 +36,7 @@ public class PersistedValue<T> where T: Codable {
                 do {
                     return try decoder.decode(T.self, from: data)
                 } catch {
-                    os_log("Failed to decode persisted value: %@", log: .general, type: .error, error.debugDescription)
+                    os_log("Failed to decode persisted value: %@", log: .general, type: .error, error.logDescription)
                     return nil
                 }
             }
@@ -63,7 +63,7 @@ public class PersistedValue<T> where T: Codable {
                     let data = try encoder.encode(newValue)
                     userDefaults.set(data, forKey: storageKey)
                 } catch {
-                    os_log("Failed to encode persisted value: %@", log: .general, type: .error, error.debugDescription)
+                    os_log("Failed to encode persisted value: %@", log: .general, type: .error, error.logDescription)
                 }
             }
         }

--- a/Sources/Location/LocationManager.swift
+++ b/Sources/Location/LocationManager.swift
@@ -126,7 +126,7 @@ extension LocationManager: RegionManager {
             }
             
             guard error == nil else {
-                os_log("Error geocoding location: %@", log: .location, type: .error, error!.localizedDescription)
+                os_log("Error geocoding location: %@", log: .location, type: .error, error!.debugDescription)
                 return
             }
             

--- a/Sources/Location/LocationManager.swift
+++ b/Sources/Location/LocationManager.swift
@@ -126,7 +126,7 @@ extension LocationManager: RegionManager {
             }
             
             guard error == nil else {
-                os_log("Error geocoding location: %@", log: .location, type: .error, error!.debugDescription)
+                os_log("Error geocoding location: %@", log: .location, type: .error, error!.logDescription)
                 return
             }
             

--- a/Sources/Location/Model/Beacon.swift
+++ b/Sources/Location/Model/Beacon.swift
@@ -99,7 +99,7 @@ extension Beacon {
         do {
             beacons = try context.fetch(fetchRequest)
         } catch {
-            os_log("Failed to fetch beacons: %@", log: .persistence, type: .error, error.debugDescription)
+            os_log("Failed to fetch beacons: %@", log: .persistence, type: .error, error.logDescription)
             return []
         }
         
@@ -114,7 +114,7 @@ extension Beacon {
             let beacons = try context.fetch(fetchRequest)
             return Set(beacons)
         } catch {
-            os_log("Failed to fetch beacons: %@", log: .persistence, type: .error, error.debugDescription)
+            os_log("Failed to fetch beacons: %@", log: .persistence, type: .error, error.logDescription)
             return []
         }
     }
@@ -125,7 +125,7 @@ extension Beacon {
         do {
             try context.execute(deleteRequest)
         } catch {
-            os_log("Failed to delete beacons: %@", log: .persistence, type: .error, error.debugDescription)
+            os_log("Failed to delete beacons: %@", log: .persistence, type: .error, error.logDescription)
         }
     }
 }

--- a/Sources/Location/Model/Beacon.swift
+++ b/Sources/Location/Model/Beacon.swift
@@ -99,7 +99,7 @@ extension Beacon {
         do {
             beacons = try context.fetch(fetchRequest)
         } catch {
-            os_log("Failed to fetch beacons: %@", log: .persistence, type: .error, error.localizedDescription)
+            os_log("Failed to fetch beacons: %@", log: .persistence, type: .error, error.debugDescription)
             return []
         }
         
@@ -114,7 +114,7 @@ extension Beacon {
             let beacons = try context.fetch(fetchRequest)
             return Set(beacons)
         } catch {
-            os_log("Failed to fetch beacons: %@", log: .persistence, type: .error, error.localizedDescription)
+            os_log("Failed to fetch beacons: %@", log: .persistence, type: .error, error.debugDescription)
             return []
         }
     }
@@ -125,7 +125,7 @@ extension Beacon {
         do {
             try context.execute(deleteRequest)
         } catch {
-            os_log("Failed to delete beacons: %@", log: .persistence, type: .error, error.localizedDescription)
+            os_log("Failed to delete beacons: %@", log: .persistence, type: .error, error.debugDescription)
         }
     }
 }

--- a/Sources/Location/Model/Geofence.swift
+++ b/Sources/Location/Model/Geofence.swift
@@ -115,7 +115,7 @@ extension Geofence {
                 os_signpost(.end, log: .persistence, name: "fetchGeofences", "type=all")
             }
         } catch {
-            os_log("Failed to fetch geofences: %@", log: .persistence, type: .error, error.debugDescription)
+            os_log("Failed to fetch geofences: %@", log: .persistence, type: .error, error.logDescription)
             return []
         }
         
@@ -143,7 +143,7 @@ extension Geofence {
                 os_signpost(.end, log: .persistence, name: "fetchGeofences", "type=regionIdentifier")
             }
         } catch {
-            os_log("Failed to fetch geofence: %@", log: .persistence, type: .error, error.debugDescription)
+            os_log("Failed to fetch geofence: %@", log: .persistence, type: .error, error.logDescription)
             return nil
         }
         
@@ -162,7 +162,7 @@ extension Geofence {
         do {
             try context.execute(deleteRequest)
         } catch {
-            os_log("Failed to delete geofences: %@", log: .persistence, type: .error, error.debugDescription)
+            os_log("Failed to delete geofences: %@", log: .persistence, type: .error, error.logDescription)
         }
     }
 }

--- a/Sources/Location/Model/Geofence.swift
+++ b/Sources/Location/Model/Geofence.swift
@@ -115,7 +115,7 @@ extension Geofence {
                 os_signpost(.end, log: .persistence, name: "fetchGeofences", "type=all")
             }
         } catch {
-            os_log("Failed to fetch geofences: %@", log: .persistence, type: .error, error.localizedDescription)
+            os_log("Failed to fetch geofences: %@", log: .persistence, type: .error, error.debugDescription)
             return []
         }
         
@@ -143,7 +143,7 @@ extension Geofence {
                 os_signpost(.end, log: .persistence, name: "fetchGeofences", "type=regionIdentifier")
             }
         } catch {
-            os_log("Failed to fetch geofence: %@", log: .persistence, type: .error, error.localizedDescription)
+            os_log("Failed to fetch geofence: %@", log: .persistence, type: .error, error.debugDescription)
             return nil
         }
         
@@ -162,7 +162,7 @@ extension Geofence {
         do {
             try context.execute(deleteRequest)
         } catch {
-            os_log("Failed to delete geofences: %@", log: .persistence, type: .error, error.localizedDescription)
+            os_log("Failed to delete geofences: %@", log: .persistence, type: .error, error.debugDescription)
         }
     }
 }

--- a/Sources/Notifications/Services/NotificationStore/NotificationStoreService.swift
+++ b/Sources/Notifications/Services/NotificationStore/NotificationStoreService.swift
@@ -69,7 +69,7 @@ class NotificationStoreService: NotificationStore {
             notifications = try PropertyListDecoder().decode([Notification].self, from: data)
             os_log("%d notification(s) restored from cache", log: .notifications, type: .debug, notifications.count)
         } catch {
-            os_log("Failed to restore notifications from cache: %@", log: .notifications, type: .error, error.debugDescription)
+            os_log("Failed to restore notifications from cache: %@", log: .notifications, type: .error, error.logDescription)
         }
     }
     
@@ -92,7 +92,7 @@ class NotificationStoreService: NotificationStore {
             userDefaults.set(unreadCount, forKey: "io.rover.unreadNotifications")
             os_log("Cache now contains notification(s)", log: .notifications, type: .debug, notifications.count)
         } catch {
-            os_log("Failed to persist notifications to cache: %@", log: .notifications, type: .error, error.debugDescription)
+            os_log("Failed to persist notifications to cache: %@", log: .notifications, type: .error, error.logDescription)
         }
     }
     

--- a/Sources/Notifications/Services/NotificationStore/NotificationStoreService.swift
+++ b/Sources/Notifications/Services/NotificationStore/NotificationStoreService.swift
@@ -69,7 +69,7 @@ class NotificationStoreService: NotificationStore {
             notifications = try PropertyListDecoder().decode([Notification].self, from: data)
             os_log("%d notification(s) restored from cache", log: .notifications, type: .debug, notifications.count)
         } catch {
-            os_log("Failed to restore notifications from cache: %@", log: .notifications, type: .error, error.localizedDescription)
+            os_log("Failed to restore notifications from cache: %@", log: .notifications, type: .error, error.debugDescription)
         }
     }
     
@@ -92,7 +92,7 @@ class NotificationStoreService: NotificationStore {
             userDefaults.set(unreadCount, forKey: "io.rover.unreadNotifications")
             os_log("Cache now contains notification(s)", log: .notifications, type: .debug, notifications.count)
         } catch {
-            os_log("Failed to persist notifications to cache: %@", log: .notifications, type: .error, error.localizedDescription)
+            os_log("Failed to persist notifications to cache: %@", log: .notifications, type: .error, error.debugDescription)
         }
     }
     

--- a/Sources/Notifications/Services/NotificationsSyncParticipant.swift
+++ b/Sources/Notifications/Services/NotificationsSyncParticipant.swift
@@ -42,7 +42,7 @@ class NotificationsSyncParticipant: SyncParticipant {
         do {
             response = try JSONDecoder.default.decode(Response.self, from: data)
         } catch {
-            os_log("Failed to decode response: %@", log: .sync, type: .error, error.debugDescription)
+            os_log("Failed to decode response: %@", log: .sync, type: .error, error.logDescription)
             return .failed
         }
         

--- a/Sources/Notifications/Services/NotificationsSyncParticipant.swift
+++ b/Sources/Notifications/Services/NotificationsSyncParticipant.swift
@@ -42,7 +42,7 @@ class NotificationsSyncParticipant: SyncParticipant {
         do {
             response = try JSONDecoder.default.decode(Response.self, from: data)
         } catch {
-            os_log("Failed to decode response: %@", log: .sync, type: .error, error.localizedDescription)
+            os_log("Failed to decode response: %@", log: .sync, type: .error, error.debugDescription)
             return .failed
         }
         


### PR DESCRIPTION
Formerly most of the log messages were using `localizedDescription`, but that is intended for display to the user in the UI in their locale, not for use in engineering logs.

This is particularly necessary for Codable errors, which include details as to why the failure occurred.  I've wanted to make this change in Campaigns for a while, as hidden errors invariably trip me up every time.  This change has already been done to the main Rover SDK.

It was already done in PersistedValue, but should have been done everywhere.