### PR TITLE
Track Ticketmaster Screen Viewed Events

### DIFF
--- a/Sources/Data/EventQueue/EventInfo.swift
+++ b/Sources/Data/EventQueue/EventInfo.swift
@@ -48,11 +48,3 @@ public extension EventInfo {
         self.init(name: "Screen Viewed", attributes: eventAttributes)
     }
 }
-
-public extension EventQueue {
-    func trackScreenViewed(screenName: String, contentID: String? = nil, contentName: String? = nil) {
-        self.addEvent(
-            EventInfo(screenViewedWithName: screenName, contentID: contentID, contentName: contentName)
-        )
-    }
-}

--- a/Sources/Data/EventQueue/EventInfo.swift
+++ b/Sources/Data/EventQueue/EventInfo.swift
@@ -30,11 +30,9 @@ public extension EventInfo {
     init(
         screenViewedWithName screenName: String,
         contentID: String? = nil,
-        contentLabel: String? = nil,
-        namespace: String? = nil,
-        attributes: Attributes? = nil
+        contentName: String? = nil
     ) {
-        let eventAttributes: Attributes = attributes ?? [:]
+        let eventAttributes: Attributes = [:]
         
         eventAttributes["screenName"] = screenName
         
@@ -42,11 +40,19 @@ public extension EventInfo {
             eventAttributes["contentID"] = contentID
         }
         
-        if let contentLabel = contentLabel {
-            eventAttributes["contentLabel"] = contentLabel
+        if let contentName = contentName {
+            eventAttributes["contentName"] = contentName
         }
 
         // using a nil namespace to represent events for screens owned by the app vendor.
-        self.init(name: "Screen Viewed", namespace: namespace, attributes: eventAttributes)
+        self.init(name: "Screen Viewed", attributes: eventAttributes)
+    }
+}
+
+public extension EventQueue {
+    func trackScreenViewed(screenName: String, contentID: String? = nil, contentName: String? = nil) {
+        self.addEvent(
+            EventInfo(screenViewedWithName: screenName, contentID: contentID, contentName: contentName)
+        )
     }
 }

--- a/Sources/Data/EventQueue/EventInfo.swift
+++ b/Sources/Data/EventQueue/EventInfo.swift
@@ -30,21 +30,23 @@ public extension EventInfo {
     init(
         forViewingScreenWithName screenName: String,
         screenLabel: String? = nil,
-        contentID: String? = nil
+        contentID: String? = nil,
+        namespace: String? = nil,
+        attributes: Attributes? = nil
     ) {
-        let attributes: Attributes = [
-            "screenName": screenName
-        ]
+        let eventAttributes: Attributes = attributes ?? [:]
+        
+        eventAttributes["screenName"] = screenName
         
         if let screenLabel = screenLabel {
-            attributes["screenLabel"] = screenLabel
+            eventAttributes["screenLabel"] = screenLabel
         }
         
         if let contentID = contentID {
-            attributes["contentID"] = contentID
+            eventAttributes["contentID"] = contentID
         }
         
         // using a nil namespace to represent events for screens owned by the app vendor.
-        self.init(name: "Screen Viewed", attributes: attributes)
+        self.init(name: "Screen Viewed", namespace: namespace, attributes: eventAttributes)
     }
 }

--- a/Sources/Data/EventQueue/EventInfo.swift
+++ b/Sources/Data/EventQueue/EventInfo.swift
@@ -28,9 +28,9 @@ public struct EventInfo {
 public extension EventInfo {
     /// Create an EventInfo that tracks a Screen Viewed event for Analytics use.  Use it for tracking screens & content in your app belonging to components other than Rover.
     init(
-        forViewingScreenWithName screenName: String,
-        screenLabel: String? = nil,
+        screenViewedWithName screenName: String,
         contentID: String? = nil,
+        contentLabel: String? = nil,
         namespace: String? = nil,
         attributes: Attributes? = nil
     ) {
@@ -38,14 +38,14 @@ public extension EventInfo {
         
         eventAttributes["screenName"] = screenName
         
-        if let screenLabel = screenLabel {
-            eventAttributes["screenLabel"] = screenLabel
-        }
-        
         if let contentID = contentID {
             eventAttributes["contentID"] = contentID
         }
         
+        if let contentLabel = contentLabel {
+            eventAttributes["contentLabel"] = contentLabel
+        }
+
         // using a nil namespace to represent events for screens owned by the app vendor.
         self.init(name: "Screen Viewed", namespace: namespace, attributes: eventAttributes)
     }

--- a/Sources/Data/EventQueue/EventQueue.swift
+++ b/Sources/Data/EventQueue/EventQueue.swift
@@ -319,3 +319,13 @@ extension EventQueue {
         }
     }
 }
+
+// MARK: Screen Tracking
+
+public extension EventQueue {
+    func trackScreenViewed(screenName: String, contentID: String? = nil, contentName: String? = nil) {
+        self.addEvent(
+            EventInfo(screenViewedWithName: screenName, contentID: contentID, contentName: contentName)
+        )
+    }
+}

--- a/Sources/Ticketmaster/TicketmasterAssembler.swift
+++ b/Sources/Ticketmaster/TicketmasterAssembler.swift
@@ -22,7 +22,8 @@ public class TicketmasterAssembler: Assembler {
         
         container.register(TicketmasterManager.self) { resolver in
             let userInfoManager = resolver.resolve(UserInfoManager.self)!
-            return TicketmasterManager(userInfoManager: userInfoManager)
+            let eventQueue = resolver.resolve(EventQueue.self)!
+            return TicketmasterManager(userInfoManager: userInfoManager, eventQueue: eventQueue)
         }
         
         container.register(SyncParticipant.self, name: "ticketmaster") { resolver in

--- a/Sources/Ticketmaster/TicketmasterManager.swift
+++ b/Sources/Ticketmaster/TicketmasterManager.swift
@@ -93,7 +93,7 @@ class TicketmasterManager {
 
         if let eventDate = notification.userInfo?["event_date"] as? Date {
             // In order to be (somewhat) consistent with the Android version of the Presence SDK (which yields a pre-rendered date string in a non-standard format), render it into the following format:
-            // Mon, Apr 13, 7 PM
+            // Mon, Apr 13, 7:00 PM
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.setLocalizedDateFormatFromTemplate("E, MMM d, h:mm a")

--- a/Sources/Ticketmaster/TicketmasterManager.swift
+++ b/Sources/Ticketmaster/TicketmasterManager.swift
@@ -124,9 +124,15 @@ class TicketmasterManager {
             artistAttributes["id"] = artistID
         }
         
-        attributes["event"] = eventAttributes
-        attributes["venue"] = venueAttributes
-        attributes["artist"] = artistAttributes
+        if !eventAttributes.rawValue.isEmpty {
+            attributes["event"] = eventAttributes
+        }
+        if !venueAttributes.rawValue.isEmpty {
+            attributes["venue"] = venueAttributes
+        }
+        if !artistAttributes.rawValue.isEmpty {
+            attributes["artist"] = artistAttributes
+        }
         
         let eventInfo = EventInfo(screenViewedWithName: roverScreenName, namespace: "ticketmaster", attributes: attributes)
         

--- a/Sources/Ticketmaster/TicketmasterManager.swift
+++ b/Sources/Ticketmaster/TicketmasterManager.swift
@@ -128,7 +128,7 @@ class TicketmasterManager {
         attributes["venue"] = venueAttributes
         attributes["artist"] = artistAttributes
         
-        let eventInfo = EventInfo(forViewingScreenWithName: roverScreenName, namespace: "ticketmaster", attributes: attributes)
+        let eventInfo = EventInfo(screenViewedWithName: roverScreenName, namespace: "ticketmaster", attributes: attributes)
         
         eventQueue.addEvent(eventInfo)
     }

--- a/Sources/Ticketmaster/TicketmasterManager.swift
+++ b/Sources/Ticketmaster/TicketmasterManager.swift
@@ -76,9 +76,9 @@ class TicketmasterManager {
             return
         }
         
-        // the same fields are common amongst all the events we monitor for.
-        let attributes: Attributes = [:]
+        let attributes: Attributes = ["screenName": roverScreenName]
         
+        // the same fields are common amongst all the events we monitor for.
         let eventAttributes: Attributes = [:]
         let venueAttributes: Attributes = [:]
         let artistAttributes: Attributes = [:]
@@ -134,7 +134,7 @@ class TicketmasterManager {
             attributes["artist"] = artistAttributes
         }
         
-        let eventInfo = EventInfo(screenViewedWithName: roverScreenName, namespace: "ticketmaster", attributes: attributes)
+        let eventInfo = EventInfo(name: "Screen Viewed", namespace: "ticketmaster", attributes: attributes)
         
         eventQueue.addEvent(eventInfo)
     }

--- a/Sources/Ticketmaster/TicketmasterManager.swift
+++ b/Sources/Ticketmaster/TicketmasterManager.swift
@@ -229,7 +229,7 @@ extension TicketmasterManager: SyncParticipant {
         do {
             response = try JSONDecoder.default.decode(Response.self, from: data)
         } catch {
-            os_log("Failed to decode response: %@", log: .sync, type: .error, error.localizedDescription)
+            os_log("Failed to decode response: %@", log: .sync, type: .error, error.logDescription)
             return .failed
         }
         

--- a/Sources/Ticketmaster/TicketmasterManager.swift
+++ b/Sources/Ticketmaster/TicketmasterManager.swift
@@ -229,7 +229,7 @@ extension TicketmasterManager: SyncParticipant {
         do {
             response = try JSONDecoder.default.decode(Response.self, from: data)
         } catch {
-            os_log("Failed to decode response: %@", log: .sync, type: .error, error.debugDescription)
+            os_log("Failed to decode response: %@", log: .sync, type: .error, error.localizedDescription)
             return .failed
         }
         

--- a/Sources/Ticketmaster/TicketmasterManager.swift
+++ b/Sources/Ticketmaster/TicketmasterManager.swift
@@ -14,7 +14,8 @@ import RoverData
 #endif
 
 class TicketmasterManager {
-    let userInfoManager: UserInfoManager
+    private let userInfoManager: UserInfoManager
+    private let eventQueue: EventQueue
     
     struct Member: Codable {
         var id: String
@@ -39,8 +40,9 @@ class TicketmasterManager {
     }
     var legacyMember = PersistedValue<LegacyMember>(storageKey: "io.rover.RoverTicketmaster")
     
-    init(userInfoManager: UserInfoManager) {
+    init(userInfoManager: UserInfoManager, eventQueue: EventQueue) {
         self.userInfoManager = userInfoManager
+        self.eventQueue = eventQueue
         
         // do migration from 3.2 and older, if needed.
         if let legacyData = legacyMember.value, member.value == nil {
@@ -55,7 +57,89 @@ class TicketmasterManager {
                 member.value = nil
             }
         }
+        
+        // Begin observing for TM PSDK's events.
+        TicketmasterManager.tmEvents.keys.forEach { notificationName in
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(self.receiveTicketmasterNotification),
+                name: NSNotification.Name(rawValue: notificationName),
+                object: nil
+            )
+        }
     }
+    
+    @objc
+    func receiveTicketmasterNotification(_ notification: Foundation.Notification) {
+        guard let roverScreenName = TicketmasterManager.tmEvents[notification.name.rawValue] else {
+            os_log("TicketmasterManager received an unexpected NSNotification, ignoring.", log: .general, type: .error)
+            return
+        }
+        
+        // the same fields are common amongst all the events we monitor for.
+        let attributes: Attributes = [:]
+        
+        let eventAttributes: Attributes = [:]
+        let venueAttributes: Attributes = [:]
+        let artistAttributes: Attributes = [:]
+        
+        if let eventID = notification.userInfo?["event_id"] {
+            eventAttributes["id"] = eventID
+        }
+        
+        if let eventName = notification.userInfo?["event_name"] {
+            eventAttributes["name"] = eventName
+        }
+
+        if let eventDate = notification.userInfo?["event_date"] as? Date {
+            // In order to be (somewhat) consistent with the Android version of the Presence SDK (which yields a pre-rendered date string in a non-standard format), render it into the following format:
+            // Mon, Apr 13, 7 PM
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.setLocalizedDateFormatFromTemplate("E, MMM d, h:mm a")
+            eventAttributes["date"] = formatter.string(from: eventDate)
+        }
+        
+        if let eventImageURL = notification.userInfo?["event_image_url"] {
+            eventAttributes["imageURL"] = eventImageURL
+        }
+        
+        if let venueName = notification.userInfo?["venue_name"] {
+            venueAttributes["name"] = venueName
+        }
+        
+        if let venueID = notification.userInfo?["venue_id"] {
+            venueAttributes["id"] = venueID
+        }
+        
+        if let currentTicketCount = notification.userInfo?["current_ticket_count"] {
+            attributes["currentTicketCount"] = currentTicketCount
+        }
+        
+        if let artistName = notification.userInfo?["artist_name"] ?? notification.userInfo?["atrist_name"] /* [sic] */ {
+            artistAttributes["name"] = artistName
+        }
+        
+        if let artistID = notification.userInfo?["artist_id"] {
+            artistAttributes["id"] = artistID
+        }
+        
+        attributes["event"] = eventAttributes
+        attributes["venue"] = venueAttributes
+        attributes["artist"] = artistAttributes
+        
+        let eventInfo = EventInfo(forViewingScreenWithName: roverScreenName, namespace: "ticketmaster", attributes: attributes)
+        
+        eventQueue.addEvent(eventInfo)
+    }
+    
+    private static let tmEvents = [
+        "TMX_MYTICKETSCREENSHOWED": "My Tickets",
+        "TMX_MANAGETICKETSCREENSHOWED": "Manage Ticket",
+        "TMX_ADDPAYMENTINFOSCREENSHOWED": "Add Payment Info",
+        "TMX_MYTICKETBARCODESCREENSHOWED": "Ticket Barcode",
+        "TMX_TICKETDETAILSSCREENSHOWED": "Ticket Details"
+    ]
 }
 
 // MARK: TicketmasterAuthorizer
@@ -145,7 +229,7 @@ extension TicketmasterManager: SyncParticipant {
         do {
             response = try JSONDecoder.default.decode(Response.self, from: data)
         } catch {
-            os_log("Failed to decode response: %@", log: .sync, type: .error, error.localizedDescription)
+            os_log("Failed to decode response: %@", log: .sync, type: .error, error.debugDescription)
             return .failed
         }
         


### PR DESCRIPTION
The Rover Campaigns Ticketmaster module now tracks the NotificationCenter events emitted by Ticketmaster's Presence SDK into Rover Screen Viewed events in the `ticketmaster` namespace, without introducing a direct dependency on the TM Presence SDK directly.

This also changes the EventInfo(forViewingScreenWithName:) constructor introduced in #92 to allow for passing in other attributes, which had been overlooked.

Resolves #93.