### PR TITLE
Adding new fetch request definition to prevent changing the public API

### DIFF
--- a/Sources/Location/Model/Beacon.swift
+++ b/Sources/Location/Model/Beacon.swift
@@ -15,8 +15,12 @@ import RoverData
 #endif
 
 public final class Beacon: NSManagedObject {
-    @nonobjc
+    @nonobjc @available(*, deprecated, message: "Please use Beacon.beaconFetchRequest() instead.")
     public class func fetchRequest() -> NSFetchRequest<Beacon> {
+        return NSFetchRequest<Beacon>(entityName: "Beacon")
+    }
+    
+    public class func beaconFetchRequest() -> NSFetchRequest<Beacon> {
         return NSFetchRequest<Beacon>(entityName: "Beacon")
     }
     
@@ -93,7 +97,7 @@ extension Beacon {
 
 extension Beacon {
     public static func fetchAll(in context: NSManagedObjectContext) -> Set<Beacon> {
-        let fetchRequest: NSFetchRequest<Beacon> = Beacon.fetchRequest()
+        let fetchRequest: NSFetchRequest<Beacon> = Beacon.beaconFetchRequest()
         let beacons: [Beacon]
         
         do {
@@ -107,7 +111,7 @@ extension Beacon {
     }
     
     public static func fetchAll(matchingRegionIdentifiers regionIdentifiers: Set<String>, in context: NSManagedObjectContext) -> Set<Beacon> {
-        let fetchRequest: NSFetchRequest<Beacon> = Beacon.fetchRequest()
+        let fetchRequest: NSFetchRequest<Beacon> = Beacon.beaconFetchRequest()
         fetchRequest.predicate = NSPredicate(format: "regionIdentifier IN %@", regionIdentifiers)
         
         do {
@@ -120,7 +124,7 @@ extension Beacon {
     }
 
     public static func deleteAll(in context: NSManagedObjectContext) {
-        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Beacon.fetchRequest() as! NSFetchRequest<NSFetchRequestResult>
+        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Beacon.beaconFetchRequest() as! NSFetchRequest<NSFetchRequestResult>
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
         do {
             try context.execute(deleteRequest)

--- a/Sources/Location/Model/Geofence.swift
+++ b/Sources/Location/Model/Geofence.swift
@@ -15,8 +15,12 @@ import RoverData
 #endif
 
 public final class Geofence: NSManagedObject {
-    @nonobjc
+    @nonobjc @available(*, deprecated, message: "Please use Geofence.geofenceFetchRequest() instead.")
     public class func fetchRequest() -> NSFetchRequest<Geofence> {
+        return NSFetchRequest<Geofence>(entityName: "Geofence")
+    }
+    
+    public class func geofenceFetchRequest() -> NSFetchRequest<Geofence> {
         return NSFetchRequest<Geofence>(entityName: "Geofence")
     }
     
@@ -99,7 +103,7 @@ extension Geofence {
 
 extension Geofence {
     public static func fetchAll(in context: NSManagedObjectContext) -> Set<Geofence> {
-        let fetchRequest: NSFetchRequest<Geofence> = Geofence.fetchRequest()
+        let fetchRequest: NSFetchRequest<Geofence> = Geofence.geofenceFetchRequest()
         let geofences: [Geofence]
         
         do {
@@ -124,7 +128,7 @@ extension Geofence {
     }
     
     public static func fetch(regionIdentifier: String, in context: NSManagedObjectContext) -> Geofence? {
-        let fetchRequest: NSFetchRequest<Geofence> = Geofence.fetchRequest()
+        let fetchRequest: NSFetchRequest<Geofence> = Geofence.geofenceFetchRequest()
         let predicate = NSPredicate(format: "regionIdentifier == %@", regionIdentifier)
         fetchRequest.predicate = predicate
         
@@ -157,7 +161,7 @@ extension Geofence {
     }
 
     public static func deleteAll(in context: NSManagedObjectContext) {
-        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Geofence.fetchRequest()  as! NSFetchRequest<NSFetchRequestResult>
+        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Geofence.geofenceFetchRequest()  as! NSFetchRequest<NSFetchRequestResult>
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
         do {
             try context.execute(deleteRequest)


### PR DESCRIPTION
This new method will be used internally to prevent issues with the ambiguous use of fetchRequest().  The existing fetchRequest methods have been marked as deprecated.