### PR TITLE
Address potential threading issue in SyncCoordinator

### DIFF
--- a/Sources/Data/SyncCoordinator/SyncCoordinatorService.swift
+++ b/Sources/Data/SyncCoordinator/SyncCoordinatorService.swift
@@ -62,41 +62,43 @@ class SyncCoordinatorService: SyncCoordinator {
         // Refactoring this wouldn't add a lot of value, so silence the closure length warning.
         // swiftlint:disable:next closure_body_length
         let task = self.client.task(with: requests) { [weak self] result in
-            guard let _self = self else {
-                return
-            }
-            
-            _self.syncTask = nil
-            
-            switch result {
-            case .error(let error, _):
-                if let error = error {
-                    os_log("Sync task failed: %@", log: .sync, type: .error, error.logDescription)
-                } else {
-                    os_log("Sync task failed", log: .sync, type: .error)
+            DispatchQueue.main.async {
+                guard let _self = self else {
+                    return
                 }
                 
-                _self.invokeCompletionHandlers(.failed)
-            case .success(let data):
-                var results = [SyncResult]()
-                var nextParticipants = [SyncParticipant]()
-                var nextRequests = [SyncRequest]()
-                var newData = newData
+                _self.syncTask = nil
                 
-                for participant in participants {
-                    let result = participant.saveResponse(data)
-                    results.append(result)
+                switch result {
+                case .error(let error, _):
+                    if let error = error {
+                        os_log("Sync task failed: %@", log: .sync, type: .error, error.logDescription)
+                    } else {
+                        os_log("Sync task failed", log: .sync, type: .error)
+                    }
                     
-                    if case .newData(let nextRequest) = result {
-                        newData = true
-                        if let nextRequest = nextRequest {
-                            nextParticipants.append(participant)
-                            nextRequests.append(nextRequest)
+                    _self.invokeCompletionHandlers(.failed)
+                case .success(let data):
+                    var results = [SyncResult]()
+                    var nextParticipants = [SyncParticipant]()
+                    var nextRequests = [SyncRequest]()
+                    var newData = newData
+                    
+                    for participant in participants {
+                        let result = participant.saveResponse(data)
+                        results.append(result)
+                        
+                        if case .newData(let nextRequest) = result {
+                            newData = true
+                            if let nextRequest = nextRequest {
+                                nextParticipants.append(participant)
+                                nextRequests.append(nextRequest)
+                            }
                         }
                     }
+                    
+                    _self.recursiveSync(participants: nextParticipants, requests: nextRequests, newData: newData)
                 }
-                
-                _self.recursiveSync(participants: nextParticipants, requests: nextRequests, newData: newData)
             }
         }
         


### PR DESCRIPTION
recursiveSync() was re-entering itself on an unknown background context context (likely from NSURLRequest).

I wrap recursiveSync's callback body submitted to a sync request being performed in DispatchQueue.main.async. This is because SyncCoordinator is stateful and having multiple threads touch its members is no bueno.

This (hopefully) may be the cause of https://github.com/judoapp/rover-issues/issues/9.